### PR TITLE
Only check for the repository owner

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    if: github.repository == 'segiddins/rubygems-await'
+    if: ${{ github.repository_owner == 'segiddins' }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Rather than checking for the full repository, it's also possible to only check the repository owner. This makes it easier to copy-paste the workflow between repositories and still prevent it from running on forks.

In another repository of mine it didn't work until I use `${{ }}` around the expression so I added that too, but this stuff is hard to test.

Fixes: 099ed50d651896433e2ede1c71938ec931cdfc90 ("Support passing paths to a .gem to await (#5)")