### PR TITLE
Fix dependencies parsing error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           - { name: ruby-3.0, value: 3.0.6 }
           - { name: ruby-3.1, value: 3.1.4 }
           - { name: ruby-3.2, value: 3.2.2 }
-          - { name: ruby-3.3, value: 3.3.0 }
+          - { name: ruby-3.3, value: 3.3.3 }
 
         include:
           - os: { name: macOS, value: macos-12 }
@@ -37,7 +37,7 @@ jobs:
             ruby: { name: ruby-3.2, value: 3.2.2 }
             timeout: 10
           - os: { name: macOS, value: macos-12 }
-            ruby: { name: ruby-3.3, value: 3.3.0 }
+            ruby: { name: ruby-3.3, value: 3.3.3 }
             timeout: 10
           - os: { name: Windows, value: windows-2022 }
             ruby: { name: ruby-3.0, value: 3.0.6 }

--- a/lib/rubygems/await.rb
+++ b/lib/rubygems/await.rb
@@ -262,7 +262,11 @@ module Rubygems
                 "unsupported bundler version: #{Bundler::VERSION}. " \
                 "#{cic.class} does not respond to #info or #update_info"
         end
-        info = cic.instance_variable_get(:@cache).dependencies(name)
+        info = if defined?(::Bundler::CompactIndexClient::Parser)
+                 cic.info(name)
+               else
+                 cic.instance_variable_get(:@cache).dependencies(name)
+               end
 
         info.each do |version, platform|
           tuple = Gem::NameTuple.new(name, version, platform)


### PR DESCRIPTION
## Summary

A refactored `Bundler::CompactIndexClient::Cache` class was released in v2.5.12, causing issues with the now missing `dependencies` method: https://github.com/rubygems/rubygems/compare/bundler-v2.5.11...bundler-v2.5.12

The same functionality is now offered by a new `Bundler::CompactIndexClient::Parser` class, and nicely exposed via the `Bundler::CompactIndexClient#info` method.

Fixes #44 